### PR TITLE
Review For Fix TGI and Support for Models Health Status Checks

### DIFF
--- a/workers/comfyui/data_types.py
+++ b/workers/comfyui/data_types.py
@@ -174,7 +174,7 @@ class CustomComfyWorkflowData(ApiPayload):
 
     @classmethod
     def for_test(cls):
-        raise NotImplemented("Custom comfy workflow is not used for testing")
+        raise NotImplementedError("Custom comfy workflow is not used for testing")
 
     def count_workload(self) -> float:
         return count_workload(

--- a/workers/comfyui/server.py
+++ b/workers/comfyui/server.py
@@ -2,7 +2,7 @@ import os
 import logging
 import dataclasses
 import base64
-from typing import Union, Type
+from typing import Optional, Union, Type
 
 from aiohttp import web, ClientResponse
 from anyio import open_file
@@ -69,7 +69,11 @@ class DefaultComfyWorkflowHandler(EndpointHandler[DefaultComfyWorkflowData]):
     @property
     def endpoint(self) -> str:
         return "/runsync"
-
+    
+    @property
+    def healthcheck_endpoint(self) -> Optional[str]:
+        return None
+    
     @classmethod
     def payload_cls(cls) -> Type[DefaultComfyWorkflowData]:
         return DefaultComfyWorkflowData
@@ -89,7 +93,11 @@ class CustomComfyWorkflowHandler(EndpointHandler[CustomComfyWorkflowData]):
     @property
     def endpoint(self) -> str:
         return "/runsync"
-
+    
+    @property
+    def healthcheck_endpoint(self) -> Optional[str]:
+        return None
+    
     @classmethod
     def payload_cls(cls) -> Type[CustomComfyWorkflowData]:
         return CustomComfyWorkflowData

--- a/workers/hello_world/server.py
+++ b/workers/hello_world/server.py
@@ -13,7 +13,7 @@ EndpointHandler. This is useful for endpoints such as healthchecks. See below fo
 import os
 import logging
 import dataclasses
-from typing import Dict, Any, Union, Type
+from typing import Dict, Any, Optional, Union, Type
 
 from aiohttp import web, ClientResponse
 
@@ -49,7 +49,11 @@ class GenerateHandler(EndpointHandler[InputData]):
     def endpoint(self) -> str:
         # the API endpoint
         return "/generate"
-
+    
+    @property
+    def healthcheck_endpoint(self) -> Optional[str]:
+        return None
+    
     @classmethod
     def payload_cls(cls) -> Type[InputData]:
         return InputData
@@ -93,7 +97,11 @@ class GenerateStreamHandler(EndpointHandler[InputData]):
     @property
     def endpoint(self) -> str:
         return "/generate_stream"
-
+    
+    @property
+    def healthcheck_endpoint(self) -> Optional[str]:
+        return None
+    
     @classmethod
     def payload_cls(cls) -> Type[InputData]:
         return InputData

--- a/workers/tgi/server.py
+++ b/workers/tgi/server.py
@@ -14,7 +14,7 @@ from .data_types import InputData
 MODEL_SERVER_URL = "http://0.0.0.0:5001"
 
 # This is the last log line that gets emitted once comfyui+extensions have been fully loaded
-MODEL_SERVER_START_LOG_MSG = '"message":"Connected","target":"text_generation_router"'
+MODEL_SERVER_START_LOG_MSG = ['"message":"Connected","target":"text_generation_router"', '"message":"Connected","target":"text_generation_router::server"']
 MODEL_SERVER_ERROR_LOG_MSGS = ["Error: WebserverFailed", "Error: DownloadError", "Error: ShardCannotStart"]
 
 
@@ -33,6 +33,10 @@ class GenerateHandler(EndpointHandler[InputData]):
     def endpoint(self) -> str:
         return "/generate"
 
+    @property
+    def healthcheck_endpoint(self) -> str:
+        return f"{MODEL_SERVER_URL}/health"
+    
     @classmethod
     def payload_cls(cls) -> Type[InputData]:
         return InputData
@@ -58,7 +62,11 @@ class GenerateStreamHandler(EndpointHandler[InputData]):
     @property
     def endpoint(self) -> str:
         return "/generate_stream"
-
+    
+    @property
+    def healthcheck_endpoint(self) -> str:
+        return f"{MODEL_SERVER_URL}/health"
+    
     @classmethod
     def payload_cls(cls) -> Type[InputData]:
         return InputData
@@ -91,7 +99,10 @@ backend = Backend(
     allow_parallel_requests=True,
     benchmark_handler=GenerateHandler(benchmark_runs=3, benchmark_words=256),
     log_actions=[
-        (LogAction.ModelLoaded, MODEL_SERVER_START_LOG_MSG),
+         *[
+            (LogAction.ModelLoaded, info_msg)
+            for info_msg in MODEL_SERVER_START_LOG_MSG
+        ],
         (LogAction.Info, '"message":"Download'),
         *[
             (LogAction.ModelError, error_msg)


### PR DESCRIPTION
### Description

Modified readiness checks to prioritize the Huggingface TGI health endpoint.
Enhanced log message detection to accommodate recent changes in Huggingface TGI's readiness notifications.
Extended functionality to support autoscaler templates for additional models, including potential future templates for platforms like ComfyUI when they also have an health check endpoint

Tested these changes with multiple Huggingface TGI versions to ensure compatibility and reliability.

### Reason for Change

Our previous approach checks for a particular string in the log, hence once it misses out on such string, it is not able to notify the autoscaler that an instance is ready. Instances would already be up and willing to serve request but autoscaler is not aware because pyworker would not have sent the right information. This has led to TGI autoscaler template not working with all versions of hugging face TGI after version 2.0.4 to the latest.

### Testing

The updates were rigorously tested across varied Huggingface TGI versions, ensuring both the health endpoint and log-based readiness checks operate seamlessly. This ensures robust detection for different configurations and versions.

### Future Work

Explore another important model endpoint, to expand pyworker functionality further.

### Links

Refer to https://huggingface.github.io/text-generation-inference for additional context and information about Huggingface TGI's health endpoint and other endpoints.





![image](https://github.com/user-attachments/assets/1940d78b-9157-4e84-b683-0fb7d77358ee)
