### PR TITLE
Ensure venv creation where python is unavailable

### DIFF
--- a/start_server.sh
+++ b/start_server.sh
@@ -46,17 +46,19 @@ env | grep _ >> /etc/environment;
 
 if [ ! -d "$ENV_PATH" ]
 then
-    apt install -y python3.10-venv
     echo "setting up venv"
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    source ~/.local/bin/env
     git clone https://github.com/vast-ai/pyworker "$SERVER_DIR"
 
-    python3 -m venv "$WORKSPACE_DIR/worker-env"
+    uv venv "$WORKSPACE_DIR/worker-env" -p 3.10
     source "$WORKSPACE_DIR/worker-env/bin/activate"
 
-    pip install -r vast-pyworker/requirements.txt
+    uv pip install -r vast-pyworker/requirements.txt
 
     touch ~/.no_auto_tmux
 else
+    source ~/.local/bin/env
     source "$WORKSPACE_DIR/worker-env/bin/activate"
     echo "environment activated"
     echo "venv: $VIRTUAL_ENV"

--- a/start_server.sh
+++ b/start_server.sh
@@ -51,7 +51,7 @@ then
     source ~/.local/bin/env
     git clone https://github.com/vast-ai/pyworker "$SERVER_DIR"
 
-    uv venv "$WORKSPACE_DIR/worker-env" -p 3.10
+    uv venv --managed-python "$WORKSPACE_DIR/worker-env" -p 3.10
     source "$WORKSPACE_DIR/worker-env/bin/activate"
 
     uv pip install -r vast-pyworker/requirements.txt


### PR DESCRIPTION
Currently we assume apt package `python3.10-venv` is available.  This is safe for images based on Ubuntu 22.04, but we now see many 24.04 images where the system Python is bumped to 3.12.

I propose that we use `uv` instead to manage the python version and requirements installation.

This guarantees a compatible Python venv without having to resort to adding additional apt repositories (deadsnakes)

