### PR TITLE
Blind hotfix to see if comfy UI default is needed. if it does work we…

### DIFF
--- a/workers/comfyui-json/server.py
+++ b/workers/comfyui-json/server.py
@@ -12,7 +12,7 @@ from lib.server import start_server
 from .data_types import ComfyWorkflowData
 
 
-MODEL_SERVER_URL = os.getenv("MODEL_SERVER_URL", "http://127.0.0.1:18288")
+MODEL_SERVER_URL = os.getenv("MODEL_SERVER_URL", "http://127.0.0.1:8288")
 
 # This is the last log line that gets emitted once comfyui+extensions have been fully loaded
 MODEL_SERVER_START_LOG_MSG = "To see the GUI go to: "

--- a/workers/comfyui/server.py
+++ b/workers/comfyui/server.py
@@ -13,10 +13,10 @@ from lib.server import start_server
 from .data_types import DefaultComfyWorkflowData, CustomComfyWorkflowData
 
 
-MODEL_SERVER_URL = "http://127.0.0.1:18288" # API Wrapper Service
+MODEL_SERVER_URL = "http://127.0.0.1:8288" # API Wrapper Service
 
 # This is the last log line that gets emitted once comfyui+extensions have been fully loaded
-MODEL_SERVER_START_LOG_MSG = "To see the GUI go to: http://127.0.0.1:18188"
+MODEL_SERVER_START_LOG_MSG = "To see the GUI go to: http://127.0.0.1:8188"
 MODEL_SERVER_ERROR_LOG_MSGS = [
     "MetadataIncompleteBuffer",  # This error is emitted when the downloaded model is corrupted
     "Value not in list: unet_name",  # This error is emitted when the model file is not there at all


### PR DESCRIPTION
Blind hotfix to see if comfy UI default is needed. if it does work we would revert back. We are able to ping the comfy UI default ports on the machine but not able to ping the ip:port shown. e.g

```bash

root@C.25569344:~$ telnet 127.0.0.1 8288
Trying 127.0.0.1...
Connected to 127.0.0.1.

```