### PR TITLE
Feat/comfyui json benchmark workflow from file

### DIFF
--- a/workers/comfyui-json/README.md
+++ b/workers/comfyui-json/README.md
@@ -12,9 +12,21 @@ A docker image is provided but you may use any if the above requirements are met
 
 ## Benchmarking
 
-A simple image generation benchmark runs when each worker initializes to validate GPU performance and identify underperforming machines.
+### Custom Benchmark Workflows
 
-The benchmark uses Stable Diffusion v1.5 with ComfyUI's default text-to-image workflow. Configure the benchmark complexity and duration using these variables:
+You can provide a custom ComfyUI workflow for benchmarking by creating `workers/comfyui-json/misc/benchmark.json`. This allows you to test performance using your preferred models and workflow complexity.
+
+**Ways to provide the benchmark file:**
+- Fork this repository and add your `benchmark.json` file
+- Write the file during worker provisioning (onstart script or setup phase)
+
+An example file is provided in the repository. To ensure varied generations, use the placeholder `__RANDOM_INT__` in place of static seed values - it will be replaced with a random integer for each benchmark run.
+
+### Default Benchmark (Fallback)
+
+If `benchmark.json` is not available, a simple image generation benchmark runs when each worker initializes. This validates GPU performance and helps identify underperforming machines.
+
+The default benchmark uses Stable Diffusion v1.5 with ComfyUI's standard text-to-image workflow. Configure it using these environment variables:
 
 | Environment Variable | Default Value | Description |
 | -------------------- | ------------- | ----------- |
@@ -24,7 +36,7 @@ The benchmark uses Stable Diffusion v1.5 with ComfyUI's default text-to-image wo
 
 Each benchmark run uses a random prompt from `misc/test_prompts.txt` and a random seed to ensure consistent GPU load patterns.
 
-### Calibrating Benchmark Duration
+#### Calibrating Fallback Benchmark Duration
 
 To screen for underperforming hardware, set `BENCHMARK_TEST_STEPS` to match your expected production workflow duration. This allows you to identify machines that won't meet performance requirements.
 

--- a/workers/comfyui-json/data_types.py
+++ b/workers/comfyui-json/data_types.py
@@ -5,6 +5,7 @@ import dataclasses
 from typing import Dict, Any
 from functools import cache
 from math import ceil
+from pathlib import Path
 
 from lib.data_types import ApiPayload, JsonDataException
 

--- a/workers/comfyui-json/data_types.py
+++ b/workers/comfyui-json/data_types.py
@@ -6,6 +6,7 @@ from typing import Dict, Any
 from functools import cache
 from math import ceil
 from pathlib import Path
+import json
 
 from lib.data_types import ApiPayload, JsonDataException
 

--- a/workers/comfyui-json/misc/benchmark.json.example
+++ b/workers/comfyui-json/misc/benchmark.json.example
@@ -1,0 +1,107 @@
+{
+    "3": {
+        "inputs": {
+            "seed": "__RANDOM_INT__",
+            "steps": 20,
+            "cfg": 8,
+            "sampler_name": "euler",
+            "scheduler": "normal",
+            "denoise": 1,
+            "model": [
+            "4",
+            0
+            ],
+            "positive": [
+            "6",
+            0
+            ],
+            "negative": [
+            "7",
+            0
+            ],
+            "latent_image": [
+            "5",
+            0
+            ]
+        },
+        "class_type": "KSampler",
+        "_meta": {
+            "title": "KSampler"
+        }
+    },
+    "4": {
+        "inputs": {
+            "ckpt_name": "v1-5-pruned-emaonly-fp16.safetensors"
+        },
+        "class_type": "CheckpointLoaderSimple",
+        "_meta": {
+            "title": "Load Checkpoint"
+        }
+    },
+    "5": {
+        "inputs": {
+            "width": 512,
+            "height": 512,
+            "batch_size": 1
+        },
+        "class_type": "EmptyLatentImage",
+        "_meta": {
+            "title": "Empty Latent Image"
+        }
+    },
+    "6": {
+        "inputs": {
+            "text": "beautiful scenery nature glass bottle landscape, , purple galaxy bottle,",
+            "clip": [
+            "4",
+            1
+            ]
+        },
+        "class_type": "CLIPTextEncode",
+        "_meta": {
+            "title": "CLIP Text Encode (Prompt)"
+        }
+    },
+    "7": {
+        "inputs": {
+            "text": "text, watermark",
+            "clip": [
+            "4",
+            1
+            ]
+        },
+        "class_type": "CLIPTextEncode",
+        "_meta": {
+            "title": "CLIP Text Encode (Prompt)"
+        }
+    },
+    "8": {
+        "inputs": {
+            "samples": [
+            "3",
+            0
+            ],
+            "vae": [
+            "4",
+            2
+            ]
+        },
+        "class_type": "VAEDecode",
+        "_meta": {
+            "title": "VAE Decode"
+        }
+    },
+    "9": {
+        "inputs": {
+            "filename_prefix": "ComfyUI",
+            "images": [
+            "8",
+            0
+            ]
+        },
+        "class_type": "SaveImage",
+        "_meta": {
+            "title": "Save Image"
+        }
+    }
+}

--- a/workers/comfyui-json/server.py
+++ b/workers/comfyui-json/server.py
@@ -19,6 +19,7 @@ MODEL_SERVER_START_LOG_MSG = "To see the GUI go to: "
 MODEL_SERVER_ERROR_LOG_MSGS = [
     "MetadataIncompleteBuffer",  # This error is emitted when the downloaded model is corrupted
     "Value not in list: ",  # This error is emitted when the model file is not there at all
+    "[ERROR] Provisioning Script failed", # Error inserted by provisioning script if models/nodes fail to download
 ]
 
 


### PR DESCRIPTION
This PR introduces the ability to benchmark the worker with a user-provided json file that can use the intended models and complexity to give a true representation of machine performance for the given workflow.

The file is to be stored at `workers/comfyui-json/misc/benchmark.json`.  If not present, the existing SD1.5 steps estimator will be used.

It is in the user's interest to provide this file.  It can be downloaded during instance provisioning, or the user can use their own fork or the pyworker repo

PR can be tested with [this Wan 2.2 template](https://candidate.vast.ai?ref_id=145102&template_id=0a0cebb335160b88bbaf3fa8e7bd1403) which uses the following overrides

```
PYWORKER_REPO=https://github.com/robballantyne/pyworker # My Fork
PYWORKER_REF=feat/comfyui-json-benchmark-workflow-from-file # My branch

# Wan2.2 models & benchmark loaded via provisioning script
PROVISIONING_SCRIPT=https://gist.githubusercontent.com/robballantyne/0de7cd1a7ccb15d3417d7e239901233f/raw/89a9ece263fcf07db9287b41e51366761bb54b62/wan2.2-serverless-benchmarking.sh
```

An example file is provided at `workers/comfyui-json/misc/benchmark.json.example`

Readme has been modified to reflect the new option