### PR TITLE
Fix healthcheck endpoint URL

### DIFF
--- a/workers/comfyui-json/server.py
+++ b/workers/comfyui-json/server.py
@@ -70,7 +70,7 @@ class ComfyWorkflowHandler(EndpointHandler[ComfyWorkflowData]):
 
     @property
     def healthcheck_endpoint(self) -> Optional[str]:
-        return "/health"
+        return f"{MODEL_SERVER_URL}/health"
 
     @classmethod
     def payload_cls(cls) -> Type[ComfyWorkflowData]:


### PR DESCRIPTION
Fixes healthcheck URL

Testing template https://cloud.vast.ai?ref_id=145102&template_id=8d85bfb9233faf563a7e9b54e5b7a2bd

```
2025-10-06 21:22:09[DEBUG] Performing healthcheck on http://127.0.0.1:18288/health
2025-10-06 21:22:09[DEBUG] creating dedicated healthcheck session
INFO:     127.0.0.1:52962 - "GET /health HTTP/1.1" 200 OK
2025-10-06 21:22:09[DEBUG] Healthcheck successful
```