### PR TITLE
fix nltk version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 vastai-sdk>=0.3.0
-nltk==3.9.4 
+nltk==3.10.0


### PR DESCRIPTION
Fixes related to https://nvd.nist.gov/vuln/detail/CVE-2026-54293