### PR TITLE
Don't require HF_TOKEN in start_server.sh

### DIFF
--- a/start_server.sh
+++ b/start_server.sh
@@ -89,7 +89,6 @@ function install_vastai_sdk() {
     fi
 }
 
-[ -n "$BACKEND" ] && [ -z "$HF_TOKEN" ] && report_error_and_exit "HF_TOKEN must be set when BACKEND is set!"
 [ -z "$CONTAINER_ID" ] && report_error_and_exit "CONTAINER_ID must be set!"
 [ "$BACKEND" = "comfyui" ] && [ -z "$COMFY_MODEL" ] && report_error_and_exit "For comfyui backends, COMFY_MODEL must be set!"
 


### PR DESCRIPTION
`start_server.sh` exited if `HF_TOKEN` was unset whenever `BACKEND` was set. Most models aren't gated, so the token isn't needed.